### PR TITLE
Aufg 2.2 - Textkorrektur

### DIFF
--- a/3-Uebungen/2017-06-23_AS_Kartendarstellung_Uebung.ipynb
+++ b/3-Uebungen/2017-06-23_AS_Kartendarstellung_Uebung.ipynb
@@ -44,7 +44,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<p>2. Lesen Sie das Shapefile Stadtviertel_generalisiert ein (zu finden im Repository unter `\"daten/Kartendarstellung/Stadtviertel_generalisiert\"`). Lassen Sie die Stadtviertel mit `basemap` anzeigen \n",
+    "<p>2. Lesen Sie das Shapefile Stadtviertel_generalisiert ein (zu finden im Repository unter `\"daten/Kartendarstellung/Stadtviertel_generalisiert\"`). Lassen Sie die Stadtviertel mit `mapplots` anzeigen \n",
     "</p> \n",
     ">Tipp: Als Ausschnitt für die Karte bieten sich folgende Bereiche an: \n",
     "- Längengrad 9.83 bis 10.05\n",


### PR DESCRIPTION
Korrektur zur Angabe der zu verwendenden Bibliothek (mapplots statt basemap)